### PR TITLE
Add query tagging to incremental_stream materialization

### DIFF
--- a/macros/materializations/incremental_stream.sql
+++ b/macros/materializations/incremental_stream.sql
@@ -128,6 +128,8 @@ CREATE TABLE IF NOT EXISTS {{ target_relation }} AS SELECT * FROM ({{sql}});
 
 
 {%- materialization incremental_stream, adapter='snowflake' -%}
+    {% set original_query_tag = set_query_tag() %}
+
     {% set target_relation = this %}
     {%- set unique_key = config.get('unique_key') -%}
     {% set incremental_strategy = config.get('incremental_strategy') or 'default' %}
@@ -155,6 +157,8 @@ CREATE TABLE IF NOT EXISTS {{ target_relation }} AS SELECT * FROM ({{sql}});
 
     {{ run_hooks(post_hooks, inside_transaction=False) }}
     {% do drop_relation_if_exists(tmp_relation) %}
+
+    {% do unset_query_tag(original_query_tag) %}
 
     {{ return({'relations': [target_relation]}) }}
 


### PR DESCRIPTION
Wrap the Snowflake incremental_stream materialization with set_query_tag/unset_query_tag, matching dbt’s native Snowflake materializations.

This lets dispatchable tag packages (e.g., yuki_snowflake_dbt_tags) to set JSON query tags for incremental_stream runs and restores the previous tag afterward.